### PR TITLE
Prevent login if no user:pass was given

### DIFF
--- a/pynexus/pynexus.py
+++ b/pynexus/pynexus.py
@@ -378,7 +378,9 @@ class Client:
         self.socket = net.connect(nexusURL.hostname, nexusURL.port, nexusURL.scheme)
 
         self.nexusConn = NexusConn(self.socket)
-        self.nexusConn.login(nexusURL.username, nexusURL.password)
+        
+        if nexusURL.username != None and nexusURL.password != None:
+            self.nexusConn.login(nexusURL.username, nexusURL.password)
 
         atexit.register(self.close)
 


### PR DESCRIPTION
If the user and pass are not passed to the client in the url, this will prevent an unsuccessful login.